### PR TITLE
Add preemption and locality related parameters for fair scheduler

### DIFF
--- a/manifests/hadoop.pp
+++ b/manifests/hadoop.pp
@@ -63,139 +63,159 @@
 #   $mapreduce_task_io_sort_factor
 #   $mapreduce_map_java_opts
 #   $mapreduce_child_java_opts
-#   $yarn_app_mapreduce_am_resource_mb        - The amount of memory the MR AppMaster needs.
-#   $yarn_app_mapreduce_am_command_opts       - Java opts for the MR App Master processes. The following symbol, if
-#                                              present, will be interpolated: @taskid@ is replaced by current TaskID
-#   $mapreduce_shuffle_memory_limit_percent   - Maximum percentage of the in-memory limit that a single shuffle can
-#                                              consume, Default: 0.25.
+#   $yarn_app_mapreduce_am_resource_mb             - The amount of memory the MR AppMaster needs.
+#   $yarn_app_mapreduce_am_command_opts            - Java opts for the MR App Master processes. The following symbol, if
+#                                                   present, will be interpolated: @taskid@ is replaced by current TaskID
+#   $mapreduce_shuffle_memory_limit_percent        - Maximum percentage of the in-memory limit that a single shuffle can
+#                                                   consume, Default: 0.25.
 #   $mapreduce_shuffle_port
-#   $mapreduce_intermediate_compression       - If true, intermediate MapReduce data
-#                                               will be compressed.  Default: true.
-#   $mapreduce_intermediate_compression_codec - Codec class to use for intermediate compression.
-#                                               Default: org.apache.hadoop.io.compress.DefaultCodec
-#   $mapreduce_output_compession              - If true, final output of MapReduce
-#                                               jobs will be compressed. Default: false.
-#   $mapreduce_output_compession_codec        - Codec class to use for final output compression.
-#                                               Default: org.apache.hadoop.io.compress.DefaultCodec
-#   $mapreduce_output_compession_type         - Whether to output compress on BLOCK or RECORD level.
-#                                               Default: RECORD
-#   $yarn_resourcemanager_recovery_enabled    - The flag to enable/disable this feature, Default false
-#                                               If this configuration property is set to true, RM will enable
-#                                               the RM-restart functionality.
-#   $yarn_nodemanager_resource_cpu_vcores     - Number of CPU cores that can be allocated for containers.
+#   $mapreduce_intermediate_compression            - If true, intermediate MapReduce data
+#                                                    will be compressed.  Default: true.
+#   $mapreduce_intermediate_compression_codec      - Codec class to use for intermediate compression.
+#                                                    Default: org.apache.hadoop.io.compress.DefaultCodec
+#   $mapreduce_output_compession                   - If true, final output of MapReduce
+#                                                    jobs will be compressed. Default: false.
+#   $mapreduce_output_compession_codec             - Codec class to use for final output compression.
+#                                                    Default: org.apache.hadoop.io.compress.DefaultCodec
+#   $mapreduce_output_compession_type              - Whether to output compress on BLOCK or RECORD level.
+#                                                    Default: RECORD
+#   $yarn_resourcemanager_recovery_enabled         - The flag to enable/disable this feature, Default false
+#                                                    If this configuration property is set to true, RM will enable
+#                                                    the RM-restart functionality.
+#   $yarn_nodemanager_resource_cpu_vcores          - Number of CPU cores that can be allocated for containers.
 #   $yarn_nodemanager_resource_memory_mb
-#   $yarn_scheduler_minimum_allocation_mb     - The minimum allocation for every container request at the RM,
-#                                               in MBs. Memory requests lower than this won't take effect, and
-#                                               the specified value will get allocated at minimum.
-#   $yarn_scheduler_maximum_allocation_mb     - The maximum allocation for every container request at the RM,
-#                                               in MBs. Memory requests higher than this won't take effect, and
-#                                               will get capped to this value.
-#   $yarn_scheduler_minimum_allocation_vcores - The minimum allocation for every container
-#                                               request at the RM, in terms of virtual CPU
-#                                               cores. Requests lower than this won't take
-#                                               effect, and the specified value will get allocated the minimum.
-#   $yarn_scheduler_maximum_allocation_vcores - The maximum allocation for every container
-#                                               request at the RM, in terms of virtual CPU
-#                                               cores. Requests higher than this won't take
-#                                               effect, and will get capped to this value.
-#   $yarn_resourcemanager_scheduler_class     - If you change this (e.g. to
-#                                               FairScheduler), you should also provide
-#                                               your own scheduler config .xml files
-#                                               outside of the cdh module.
-#   $yarn_aux_services_spark_shuffle_enabled  - If enable spark_shuffle service.  Default: false
+#   $yarn_scheduler_minimum_allocation_mb          - The minimum allocation for every container request at the RM,
+#                                                    in MBs. Memory requests lower than this won't take effect, and
+#                                                    the specified value will get allocated at minimum.
+#   $yarn_scheduler_maximum_allocation_mb          - The maximum allocation for every container request at the RM,
+#                                                    in MBs. Memory requests higher than this won't take effect, and
+#                                                    will get capped to this value.
+#   $yarn_scheduler_minimum_allocation_vcores      - The minimum allocation for every container
+#                                                    request at the RM, in terms of virtual CPU
+#                                                    cores. Requests lower than this won't take
+#                                                    effect, and the specified value will get allocated the minimum.
+#   $yarn_scheduler_maximum_allocation_vcores      - The maximum allocation for every container
+#                                                    request at the RM, in terms of virtual CPU
+#                                                    cores. Requests higher than this won't take
+#                                                    effect, and will get capped to this value.
+#   $yarn_resourcemanager_scheduler_class          - If you change this (e.g. to
+#                                                    FairScheduler), you should also provide
+#                                                    your own scheduler config .xml files
+#                                                    outside of the cdh module.
+#   $yarn_aux_services_spark_shuffle_enabled       - If enable spark_shuffle service.  Default: false
 #
-#   $hadoop_heapsize                          - -Xmx for NameNode and DataNode.  Default: undef
-#   $yarn_heapsize                            - -Xmx for YARN Daemons.           Default: undef
-#   $ganglia_hosts                            - Set this to an array of ganglia host:ports
-#                                               if you want to enable ganglia sinks in hadoop-metrics2.properites
-#   $net_topology_script_template             - Puppet ERb template path  to script that will be
-#                                               invoked to resolve node names to row or rack assignments.
-#                                               Default: undef
-#   $gelf_logging_enabled                     - Set this to true in order to configure GELF logging output, for Logstash
-#                                             - Needs: libjson-simple-java (Debian package)
-#                                             - Needs: logstash-gelf.jar (https://github.com/mp911de/logstash-gelf/releases)
-#   $gelf_logging_host                        - Destination host for GELF output. Default is localhost.
-#   $gelf_logging_port                        - Destination port for GELF output. Default is 12201.
-#   $fair_scheduler_template                  - The fair-scheduler.xml queue configuration template.
-#                                               If you set this to false or undef, FairScheduler will
-#                                               be disabled.  Default: cdh/hadoop/fair-scheduler.xml.erb
-#   $fair_user_as_default_queue               - Whether to use the username associated with the
-#                                               allocation as the default queue name. Default: false
-#   $hadoop_classpath                         - Add library in HADOOP_CLASSPATH with hadoop-env.sh.
-#   $java_library_path                        - Add library in JAVA_LIBRARY_PATH with hadoop-env.sh.
-#   $lzo_enabled                              - Set true when you add LZO compress.
-#   $io_compression_codec_lzo_class           - Write LZO class name.            Default: com.hadoop.compression.lzo.LzoCodec
-#   $io_compression_codecs                    - A list of the compression codec classes that can be used for compression/decompression.
+#   $hadoop_heapsize                               - -Xmx for NameNode and DataNode.  Default: undef
+#   $yarn_heapsize                                 - -Xmx for YARN Daemons.           Default: undef
+#   $ganglia_hosts                                 - Set this to an array of ganglia host:ports
+#                                                    if you want to enable ganglia sinks in hadoop-metrics2.properites
+#   $net_topology_script_template                  - Puppet ERb template path  to script that will be
+#                                                    invoked to resolve node names to row or rack assignments.
+#                                                    Default: undef
+#   $gelf_logging_enabled                          - Set this to true in order to configure GELF logging output, for Logstash
+#                                                  - Needs: libjson-simple-java (Debian package)
+#                                                  - Needs: logstash-gelf.jar (https://github.com/mp911de/logstash-gelf/releases)
+#   $gelf_logging_host                             - Destination host for GELF output. Default is localhost.
+#   $gelf_logging_port                             - Destination port for GELF output. Default is 12201.
+#   $fair_scheduler_template                       - The fair-scheduler.xml queue configuration template.
+#                                                    If you set this to false or undef, FairScheduler will
+#                                                    be disabled.  Default: cdh/hadoop/fair-scheduler.xml.erb
+#   $fair_user_as_default_queue                    - Whether to use the username associated with the
+#                                                    allocation as the default queue name. Default: false
+#   $fair_preemption                               - Whether to use preemption.  Default: false
+#   $fair_preemption_cluster_utilization_threshold - The utilization threshold after which
+#                                                    preemption kicks in.  Default: undef
+#   $fair_locality_threshold_node                  - For applications that request containers
+#                                                    on particular nodes, the number of scheduling
+#                                                    opportunities since the last container
+#                                                    assignment to wait before accepting a
+#                                                    placement on another node.  Default: undef
+#   $queue_max_apps_default                        - Sets the default running app limit for queues.  Default: 50
+#   $default_fair_share_preemption_timeout         - Sets the fair share preemption timeout (second)
+#                                                    for the root queue.  Default: 30
+#   $default_fair_share_preemption_threshold       - Sets the fair share preemption threshold
+#                                                    for the root queue.  Default: 0.5
+#
+#   $hadoop_classpath                              - Add library in HADOOP_CLASSPATH with hadoop-env.sh.
+#   $java_library_path                             - Add library in JAVA_LIBRARY_PATH with hadoop-env.sh.
+#   $lzo_enabled                                   - Set true when you add LZO compress.
+#   $io_compression_codec_lzo_class                - Write LZO class name.            Default: com.hadoop.compression.lzo.LzoCodec
+#   $io_compression_codecs                         - A list of the compression codec classes that can be used for compression/decompression.
 #
 class cdh::hadoop(
     $namenode_hosts,
     $dfs_name_dir,
-    $cluster_name                                = $::cdh::hadoop::defaults::cluster_name,
-    $mapreduce_enabled                           = $::cdh::hadoop::defaults::mapreduce_enabled,
-    $journalnode_hosts                           = $::cdh::hadoop::defaults::journalnode_hosts,
-    $dfs_journalnode_edits_dir                   = $::cdh::hadoop::defaults::dfs_journalnode_edits_dir,
+    $cluster_name                                  = $::cdh::hadoop::defaults::cluster_name,
+    $mapreduce_enabled                             = $::cdh::hadoop::defaults::mapreduce_enabled,
+    $journalnode_hosts                             = $::cdh::hadoop::defaults::journalnode_hosts,
+    $dfs_journalnode_edits_dir                     = $::cdh::hadoop::defaults::dfs_journalnode_edits_dir,
 
-    $short_circuit_reads_enabled                 = $::cdh::hadoop::defaults::short_circuit_reads_enabled,
-    $block_location_tracking_enabled             = $::cdh::hadoop::defaults::block_location_tracking_enabled,
-    $azkaban_enabled                             = $::cdh::hadoop::defaults::azkaban_enabled,
+    $short_circuit_reads_enabled                   = $::cdh::hadoop::defaults::short_circuit_reads_enabled,
+    $block_location_tracking_enabled               = $::cdh::hadoop::defaults::block_location_tracking_enabled,
+    $azkaban_enabled                               = $::cdh::hadoop::defaults::azkaban_enabled,
 
-    $datanode_mounts                             = $::cdh::hadoop::defaults::datanode_mounts,
-    $dfs_data_path                               = $::cdh::hadoop::defaults::dfs_data_path,
+    $datanode_mounts                               = $::cdh::hadoop::defaults::datanode_mounts,
+    $dfs_data_path                                 = $::cdh::hadoop::defaults::dfs_data_path,
 
-    $yarn_local_path                             = $::cdh::hadoop::defaults::yarn_local_path,
-    $yarn_logs_path                              = $::cdh::hadoop::defaults::yarn_logs_path,
-    $dfs_block_size                              = $::cdh::hadoop::defaults::dfs_block_size,
-    $enable_jmxremote                            = $::cdh::hadoop::defaults::enable_jmxremote,
-    $webhdfs_enabled                             = $::cdh::hadoop::defaults::webhdfs_enabled,
-    $httpfs_enabled                              = $::cdh::hadoop::defaults::httpfs_enabled,
-    $io_file_buffer_size                         = $::cdh::hadoop::defaults::io_file_buffer_size,
-    $balance_speed                               = $::cdh::hadoop::defaults::balance_speed,
-    $mapreduce_system_dir                        = $::cdh::hadoop::defaults::mapreduce_system_dir,
-    $mapreduce_map_tasks_maximum                 = $::cdh::hadoop::defaults::mapreduce_map_tasks_maximum,
-    $mapreduce_reduce_tasks_maximum              = $::cdh::hadoop::defaults::mapreduce_reduce_tasks_maximum,
-    $mapreduce_job_reuse_jvm_num_tasks           = $::cdh::hadoop::defaults::mapreduce_job_reuse_jvm_num_tasks,
-    $mapreduce_reduce_shuffle_parallelcopies     = $::cdh::hadoop::defaults::mapreduce_reduce_shuffle_parallelcopies,
-    $mapreduce_map_memory_mb                     = $::cdh::hadoop::defaults::mapreduce_map_memory_mb,
-    $mapreduce_reduce_memory_mb                  = $::cdh::hadoop::defaults::mapreduce_reduce_memory_mb,
-    $yarn_app_mapreduce_am_resource_mb           = $::cdh::hadoop::defaults::yarn_app_mapreduce_am_resource_mb,
-    $yarn_app_mapreduce_am_command_opts          = $::cdh::hadoop::defaults::yarn_app_mapreduce_am_command_opts,
-    $mapreduce_task_io_sort_mb                   = $::cdh::hadoop::defaults::mapreduce_task_io_sort_mb,
-    $mapreduce_task_io_sort_factor               = $::cdh::hadoop::defaults::mapreduce_task_io_sort_factor,
-    $mapreduce_map_java_opts                     = $::cdh::hadoop::defaults::mapreduce_map_java_opts,
-    $mapreduce_reduce_java_opts                  = $::cdh::hadoop::defaults::mapreduce_reduce_java_opts,
-    $mapreduce_shuffle_port                      = $::cdh::hadoop::defaults::mapreduce_shuffle_port,
-    $mapreduce_shuffle_memory_limit_percent      = $::cdh::hadoop::defaults::mapreduce_shuffle_memory_limit_percent,
-    $mapreduce_intermediate_compression          = $::cdh::hadoop::defaults::mapreduce_intermediate_compression,
-    $mapreduce_intermediate_compression_codec    = $::cdh::hadoop::defaults::mapreduce_intermediate_compression_codec,
-    $mapreduce_output_compression                = $::cdh::hadoop::defaults::mapreduce_output_compession,
-    $mapreduce_output_compression_codec          = $::cdh::hadoop::defaults::mapreduce_output_compession_codec,
-    $mapreduce_output_compression_type           = $::cdh::hadoop::defaults::mapreduce_output_compression_type,
-    $yarn_resourcemanager_recovery_enabled       = $::cdh::hadoop::defaults::yarn_resourcemanager_recovery_enabled,
-    $yarn_nodemanager_resource_cpu_vcores        = $::cdh::hadoop::defaults::yarn_nodemanager_resource_cpu_vcores,
-    $yarn_nodemanager_resource_memory_mb         = $::cdh::hadoop::defaults::yarn_nodemanager_resource_memory_mb,
-    $yarn_scheduler_minimum_allocation_mb        = $::cdh::hadoop::defaults::yarn_scheduler_minimum_allocation_mb,
-    $yarn_scheduler_maximum_allocation_mb        = $::cdh::hadoop::defaults::yarn_scheduler_maximum_allocation_mb,
-    $yarn_scheduler_minimum_allocation_vcores    = $::cdh::hadoop::defaults::yarn_scheduler_minimum_allocation_vcores,
-    $yarn_scheduler_maximum_allocation_vcores    = $::cdh::hadoop::defaults::yarn_scheduler_maximum_allocation_vcores,
-    $yarn_aux_services_spark_shuffle_enabled     = $::cdh::hadoop::defaults::yarn_aux_services_spark_shuffle_enabled,
+    $yarn_local_path                               = $::cdh::hadoop::defaults::yarn_local_path,
+    $yarn_logs_path                                = $::cdh::hadoop::defaults::yarn_logs_path,
+    $dfs_block_size                                = $::cdh::hadoop::defaults::dfs_block_size,
+    $enable_jmxremote                              = $::cdh::hadoop::defaults::enable_jmxremote,
+    $webhdfs_enabled                               = $::cdh::hadoop::defaults::webhdfs_enabled,
+    $httpfs_enabled                                = $::cdh::hadoop::defaults::httpfs_enabled,
+    $io_file_buffer_size                           = $::cdh::hadoop::defaults::io_file_buffer_size,
+    $balance_speed                                 = $::cdh::hadoop::defaults::balance_speed,
+    $mapreduce_system_dir                          = $::cdh::hadoop::defaults::mapreduce_system_dir,
+    $mapreduce_map_tasks_maximum                   = $::cdh::hadoop::defaults::mapreduce_map_tasks_maximum,
+    $mapreduce_reduce_tasks_maximum                = $::cdh::hadoop::defaults::mapreduce_reduce_tasks_maximum,
+    $mapreduce_job_reuse_jvm_num_tasks             = $::cdh::hadoop::defaults::mapreduce_job_reuse_jvm_num_tasks,
+    $mapreduce_reduce_shuffle_parallelcopies       = $::cdh::hadoop::defaults::mapreduce_reduce_shuffle_parallelcopies,
+    $mapreduce_map_memory_mb                       = $::cdh::hadoop::defaults::mapreduce_map_memory_mb,
+    $mapreduce_reduce_memory_mb                    = $::cdh::hadoop::defaults::mapreduce_reduce_memory_mb,
+    $yarn_app_mapreduce_am_resource_mb             = $::cdh::hadoop::defaults::yarn_app_mapreduce_am_resource_mb,
+    $yarn_app_mapreduce_am_command_opts            = $::cdh::hadoop::defaults::yarn_app_mapreduce_am_command_opts,
+    $mapreduce_task_io_sort_mb                     = $::cdh::hadoop::defaults::mapreduce_task_io_sort_mb,
+    $mapreduce_task_io_sort_factor                 = $::cdh::hadoop::defaults::mapreduce_task_io_sort_factor,
+    $mapreduce_map_java_opts                       = $::cdh::hadoop::defaults::mapreduce_map_java_opts,
+    $mapreduce_reduce_java_opts                    = $::cdh::hadoop::defaults::mapreduce_reduce_java_opts,
+    $mapreduce_shuffle_port                        = $::cdh::hadoop::defaults::mapreduce_shuffle_port,
+    $mapreduce_shuffle_memory_limit_percent        = $::cdh::hadoop::defaults::mapreduce_shuffle_memory_limit_percent,
+    $mapreduce_intermediate_compression            = $::cdh::hadoop::defaults::mapreduce_intermediate_compression,
+    $mapreduce_intermediate_compression_codec      = $::cdh::hadoop::defaults::mapreduce_intermediate_compression_codec,
+    $mapreduce_output_compression                  = $::cdh::hadoop::defaults::mapreduce_output_compession,
+    $mapreduce_output_compression_codec            = $::cdh::hadoop::defaults::mapreduce_output_compession_codec,
+    $mapreduce_output_compression_type             = $::cdh::hadoop::defaults::mapreduce_output_compression_type,
+    $yarn_resourcemanager_recovery_enabled         = $::cdh::hadoop::defaults::yarn_resourcemanager_recovery_enabled,
+    $yarn_nodemanager_resource_cpu_vcores          = $::cdh::hadoop::defaults::yarn_nodemanager_resource_cpu_vcores,
+    $yarn_nodemanager_resource_memory_mb           = $::cdh::hadoop::defaults::yarn_nodemanager_resource_memory_mb,
+    $yarn_scheduler_minimum_allocation_mb          = $::cdh::hadoop::defaults::yarn_scheduler_minimum_allocation_mb,
+    $yarn_scheduler_maximum_allocation_mb          = $::cdh::hadoop::defaults::yarn_scheduler_maximum_allocation_mb,
+    $yarn_scheduler_minimum_allocation_vcores      = $::cdh::hadoop::defaults::yarn_scheduler_minimum_allocation_vcores,
+    $yarn_scheduler_maximum_allocation_vcores      = $::cdh::hadoop::defaults::yarn_scheduler_maximum_allocation_vcores,
+    $yarn_aux_services_spark_shuffle_enabled       = $::cdh::hadoop::defaults::yarn_aux_services_spark_shuffle_enabled,
 
-    $fair_scheduler_template                     = $::cdh::hadoop::defaults::fair_scheduler_template,
-    $fair_user_as_default_queue                  = $::cdh::hadoop::defaults::fair_user_as_default_queue,
+    $fair_scheduler_template                       = $::cdh::hadoop::defaults::fair_scheduler_template,
+    $fair_user_as_default_queue                    = $::cdh::hadoop::defaults::fair_user_as_default_queue,
+    $fair_preemption                               = $::cdh::hadoop::defaults::fair_preemption,
+    $fair_preemption_cluster_utilization_threshold = $::cdh::hadoop::defaults::fair_preemption_cluster_utilization_threshold,
+    $fair_locality_threshold_node                  = $::cdh::hadoop::defaults::fair_locality_threshold_node,
+    $queue_max_apps_default                        = $::cdh::hadoop::defaults::queue_max_apps_default,
+    $default_fair_share_preemption_timeout         = $::cdh::hadoop::defaults::default_fair_share_preemption_timeout,
+    $default_fair_share_preemption_threshold       = $::cdh::hadoop::defaults::default_fair_share_preemption_threshold,
 
-    $hadoop_heapsize                             = $::cdh::hadoop::defaults::hadoop_heapsize,
-    $yarn_heapsize                               = $::cdh::hadoop::defaults::yarn_heapsize,
+    $hadoop_heapsize                               = $::cdh::hadoop::defaults::hadoop_heapsize,
+    $yarn_heapsize                                 = $::cdh::hadoop::defaults::yarn_heapsize,
 
-    $ganglia_hosts                               = $::cdh::hadoop::defaults::ganglia_hosts,
-    $net_topology_script_template                = $::cdh::hadoop::defaults::net_topology_script_template,
-    $gelf_logging_enabled                        = $::cdh::hadoop::defaults::gelf_logging_enabled,
-    $gelf_logging_host                           = $::cdh::hadoop::defaults::gelf_logging_host,
-    $gelf_logging_port                           = $::cdh::hadoop::defaults::gelf_logging_port,
+    $ganglia_hosts                                 = $::cdh::hadoop::defaults::ganglia_hosts,
+    $net_topology_script_template                  = $::cdh::hadoop::defaults::net_topology_script_template,
+    $gelf_logging_enabled                          = $::cdh::hadoop::defaults::gelf_logging_enabled,
+    $gelf_logging_host                             = $::cdh::hadoop::defaults::gelf_logging_host,
+    $gelf_logging_port                             = $::cdh::hadoop::defaults::gelf_logging_port,
 
-    $hadoop_classpath                            = $::cdh::hadoop::defaults::hadoop_classpath,
-    $java_library_path                           = $::cdh::hadoop::defaults::java_library_path,
-    $lzo_enabled                                 = $::cdh::hadoop::defaults::lzo_enabled,
-    $io_compression_codec_lzo_class              = $::cdh::hadoop::defaults::io_compression_codec_lzo_class,
-    $io_compression_codecs                       = $::cdh::hadoop::defaults::io_compression_codecs,
+    $hadoop_classpath                              = $::cdh::hadoop::defaults::hadoop_classpath,
+    $java_library_path                             = $::cdh::hadoop::defaults::java_library_path,
+    $lzo_enabled                                   = $::cdh::hadoop::defaults::lzo_enabled,
+    $io_compression_codec_lzo_class                = $::cdh::hadoop::defaults::io_compression_codec_lzo_class,
+    $io_compression_codecs                         = $::cdh::hadoop::defaults::io_compression_codecs,
 ) inherits cdh::hadoop::defaults
 {
     # If $dfs_name_dir is a list, this will be the

--- a/manifests/hadoop.pp
+++ b/manifests/hadoop.pp
@@ -129,6 +129,11 @@
 #                                                    opportunities since the last container
 #                                                    assignment to wait before accepting a
 #                                                    placement on another node.  Default: undef
+#   $fair_locality_threshold_rack                  - For applications that request containers
+#                                                    on particular racks, the number of scheduling
+#                                                    opportunities since the last container
+#                                                    assignment to wait before accepting a
+#                                                    placement on another rack.  Default: undef
 #   $queue_max_apps_default                        - Sets the default running app limit for queues.  Default: 50
 #   $default_fair_share_preemption_timeout         - Sets the fair share preemption timeout (second)
 #                                                    for the root queue.  Default: 30
@@ -198,6 +203,7 @@ class cdh::hadoop(
     $fair_preemption                               = $::cdh::hadoop::defaults::fair_preemption,
     $fair_preemption_cluster_utilization_threshold = $::cdh::hadoop::defaults::fair_preemption_cluster_utilization_threshold,
     $fair_locality_threshold_node                  = $::cdh::hadoop::defaults::fair_locality_threshold_node,
+    $fair_locality_threshold_rack                  = $::cdh::hadoop::defaults::fair_locality_threshold_rack,
     $queue_max_apps_default                        = $::cdh::hadoop::defaults::queue_max_apps_default,
     $default_fair_share_preemption_timeout         = $::cdh::hadoop::defaults::default_fair_share_preemption_timeout,
     $default_fair_share_preemption_threshold       = $::cdh::hadoop::defaults::default_fair_share_preemption_threshold,

--- a/manifests/hadoop/defaults.pp
+++ b/manifests/hadoop/defaults.pp
@@ -60,6 +60,7 @@ class cdh::hadoop::defaults {
     $fair_preemption                               = false
     $fair_preemption_cluster_utilization_threshold = undef
     $fair_locality_threshold_node                  = undef
+    $fair_locality_threshold_rack                  = undef
     $queue_max_apps_default                        = 50
     $default_fair_share_preemption_timeout         = 30  # second
     $default_fair_share_preemption_threshold       = 0.5

--- a/manifests/hadoop/defaults.pp
+++ b/manifests/hadoop/defaults.pp
@@ -3,83 +3,89 @@
 #
 class cdh::hadoop::defaults {
     $cluster_name = 'cdh'
-    $mapreduce_enabled                        = true
-    $journalnode_hosts                        = undef
-    $dfs_journalnode_edits_dir                = undef
+    $mapreduce_enabled                             = true
+    $journalnode_hosts                             = undef
+    $dfs_journalnode_edits_dir                     = undef
 
-    $short_circuit_reads_enabled              = false
-    $dfs_domain_socket_path                   = '/var/run/hdfs-sockets/dn'
-    $block_location_tracking_enabled          = false
-    $azkaban_enabled                          = false
+    $short_circuit_reads_enabled                   = false
+    $dfs_domain_socket_path                        = '/var/run/hdfs-sockets/dn'
+    $block_location_tracking_enabled               = false
+    $azkaban_enabled                               = false
 
-    $datanode_mounts                          = undef
-    $dfs_data_path                            = 'hdfs/dn'
-    $yarn_local_path                          = 'yarn/local'
-    $yarn_logs_path                           = 'yarn/logs'
-    $dfs_block_size                           = 67108864 # 64MB default
-    $enable_jmxremote                         = true
-    $webhdfs_enabled                          = false
-    $httpfs_enabled                           = true
-    $mapreduce_system_dir                     = undef
-    $io_file_buffer_size                      = undef
-    $balance_speed                            = undef
+    $datanode_mounts                               = undef
+    $dfs_data_path                                 = 'hdfs/dn'
+    $yarn_local_path                               = 'yarn/local'
+    $yarn_logs_path                                = 'yarn/logs'
+    $dfs_block_size                                = 67108864 # 64MB default
+    $enable_jmxremote                              = true
+    $webhdfs_enabled                               = false
+    $httpfs_enabled                                = true
+    $mapreduce_system_dir                          = undef
+    $io_file_buffer_size                           = undef
+    $balance_speed                                 = undef
 
-    $mapreduce_map_tasks_maximum              = undef
-    $mapreduce_reduce_tasks_maximum           = undef
-    $mapreduce_job_reuse_jvm_num_tasks        = undef
-    $mapreduce_reduce_shuffle_parallelcopies  = undef
+    $mapreduce_map_tasks_maximum                   = undef
+    $mapreduce_reduce_tasks_maximum                = undef
+    $mapreduce_job_reuse_jvm_num_tasks             = undef
+    $mapreduce_reduce_shuffle_parallelcopies       = undef
 
-    $mapreduce_map_memory_mb                  = undef
-    $mapreduce_reduce_memory_mb               = undef
-    $mapreduce_task_io_sort_mb                = undef
-    $mapreduce_task_io_sort_factor            = undef
-    $mapreduce_map_java_opts                  = undef
-    $mapreduce_reduce_java_opts               = undef
-    $yarn_app_mapreduce_am_resource_mb        = undef
-    $yarn_app_mapreduce_am_command_opts       = undef
+    $mapreduce_map_memory_mb                       = undef
+    $mapreduce_reduce_memory_mb                    = undef
+    $mapreduce_task_io_sort_mb                     = undef
+    $mapreduce_task_io_sort_factor                 = undef
+    $mapreduce_map_java_opts                       = undef
+    $mapreduce_reduce_java_opts                    = undef
+    $yarn_app_mapreduce_am_resource_mb             = undef
+    $yarn_app_mapreduce_am_command_opts            = undef
 
-    $mapreduce_shuffle_port                   = undef
-    $mapreduce_shuffle_memory_limit_percent   = undef
-    $mapreduce_intermediate_compression       = false
-    $mapreduce_intermediate_compression_codec = 'org.apache.hadoop.io.compress.DefaultCodec'
-    $mapreduce_output_compression             = false
-    $mapreduce_output_compression_codec       = 'org.apache.hadoop.io.compress.DefaultCodec'
-    $mapreduce_output_compression_type        = 'RECORD'
+    $mapreduce_shuffle_port                        = undef
+    $mapreduce_shuffle_memory_limit_percent        = undef
+    $mapreduce_intermediate_compression            = false
+    $mapreduce_intermediate_compression_codec      = 'org.apache.hadoop.io.compress.DefaultCodec'
+    $mapreduce_output_compression                  = false
+    $mapreduce_output_compression_codec            = 'org.apache.hadoop.io.compress.DefaultCodec'
+    $mapreduce_output_compression_type             = 'RECORD'
 
-    $yarn_resourcemanager_recovery_enabled    = false
-    $yarn_nodemanager_resource_cpu_vcores     = undef
-    $yarn_nodemanager_resource_memory_mb      = undef
-    $yarn_scheduler_minimum_allocation_mb     = undef
-    $yarn_scheduler_maximum_allocation_mb     = undef
-    $yarn_scheduler_minimum_allocation_vcores = undef
-    $yarn_scheduler_maximum_allocation_vcores = undef
-    $yarn_aux_services_spark_shuffle_enabled  = false
+    $yarn_resourcemanager_recovery_enabled         = false
+    $yarn_nodemanager_resource_cpu_vcores          = undef
+    $yarn_nodemanager_resource_memory_mb           = undef
+    $yarn_scheduler_minimum_allocation_mb          = undef
+    $yarn_scheduler_maximum_allocation_mb          = undef
+    $yarn_scheduler_minimum_allocation_vcores      = undef
+    $yarn_scheduler_maximum_allocation_vcores      = undef
+    $yarn_aux_services_spark_shuffle_enabled       = false
 
-    $fair_scheduler_template                  = 'cdh/hadoop/fair-scheduler.xml.erb'
-    $fair_user_as_default_queue               = false
+    $fair_scheduler_template                       = 'cdh/hadoop/fair-scheduler.xml.erb'
+    $fair_user_as_default_queue                    = false
+    $fair_preemption                               = false
+    $fair_preemption_cluster_utilization_threshold = undef
+    $fair_locality_threshold_node                  = undef
+    $queue_max_apps_default                        = 50
+    $default_fair_share_preemption_timeout         = 30  # second
+    $default_fair_share_preemption_threshold       = 0.5
 
-    $hadoop_heapsize                          = undef
-    $yarn_heapsize                            = undef
+    $hadoop_heapsize                               = undef
+    $yarn_heapsize                                 = undef
 
-    $ganglia_hosts                            = undef
-    $net_topology_script_template             = undef
-    $gelf_logging_enabled                     = false
-    $gelf_logging_host                        = 'localhost'
-    $gelf_logging_port                        = 12201
+    $ganglia_hosts                                 = undef
+    $net_topology_script_template                  = undef
+    $gelf_logging_enabled                          = false
+    $gelf_logging_host                             = 'localhost'
+    $gelf_logging_port                             = 12201
 
-    $hadoop_classpath                         = undef
-    $java_library_path                        = undef
+    $hadoop_classpath                              = undef
+    $java_library_path                             = undef
 
-    $lzo_enabled                              = false
-    $io_compression_codec_lzo_class           = 'com.hadoop.compression.lzo.LzoCodec'
-    $io_compression_codecs                    = ['org.apache.hadoop.io.compress.DefaultCodec',
-                                                 'org.apache.hadoop.io.compress.GzipCodec',
-                                                 'org.apache.hadoop.io.compress.BZip2Codec']
+    $lzo_enabled                                   = false
+    $io_compression_codec_lzo_class                = 'com.hadoop.compression.lzo.LzoCodec'
+    $io_compression_codecs                         = ['org.apache.hadoop.io.compress.DefaultCodec',
+                                                      'org.apache.hadoop.io.compress.GzipCodec',
+                                                      'org.apache.hadoop.io.compress.BZip2Codec']
 
     # JMX Ports (These are not currently configurable)
-    $namenode_jmxremote_port           = 9980
-    $datanode_jmxremote_port           = 9981
-    $resourcemanager_jmxremote_port    = 9983
-    $nodemanager_jmxremote_port        = 9984
-    $proxyserver_jmxremote_port        = 9985
+    $namenode_jmxremote_port                       = 9980
+    $datanode_jmxremote_port                       = 9981
+    $resourcemanager_jmxremote_port                = 9983
+    $nodemanager_jmxremote_port                    = 9984
+    $proxyserver_jmxremote_port                    = 9985
 }

--- a/templates/hadoop/fair-scheduler.xml.erb
+++ b/templates/hadoop/fair-scheduler.xml.erb
@@ -1,10 +1,6 @@
 <?xml version="1.0"?>
 <allocations>
-  <fairSharePreemptionTimeout>30</fairSharePreemptionTimeout>
-
-  <queue name="default">
-    <maxRunningApps>50</maxRunningApps>
-    <schedulingMode>fair</schedulingMode>
-  </queue>
-
+  <queueMaxAppsDefault><%= @queue_max_apps_default %></queueMaxAppsDefault>
+  <defaultFairSharePreemptionTimeout><%= @default_fair_share_preemption_timeout %></defaultFairSharePreemptionTimeout>
+  <defaultFairSharePreemptionThreshold><%= @default_fair_share_preemption_threshold %></defaultFairSharePreemptionThreshold>
 </allocations>

--- a/templates/hadoop/yarn-site.xml.erb
+++ b/templates/hadoop/yarn-site.xml.erb
@@ -17,7 +17,6 @@
     <name>yarn.resourcemanager.scheduler.class</name>
     <value>org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler</value>
   </property>
-
   <property>
     <name>yarn.scheduler.fair.allocation.file</name>
     <value><%= @config_directory %>/fair-scheduler.xml</value>
@@ -27,7 +26,6 @@
       in XML format as described in the next section.
     </description>
   </property>
-
   <property>
     <name>yarn.scheduler.fair.user-as-default-queue</name>
     <value><%= @fair_user_as_default_queue %></value>
@@ -37,7 +35,30 @@
       or unset, all jobs have a shared default queue, called "default". Defaults to true.
     </description>
   </property>
-<% end -%>
+  <property>
+    <name>yarn.scheduler.fair.preemption</name>
+    <value><%= @fair_preemption %></value>
+    <description>Whether to use preemption.</description>
+  </property>
+<% if @fair_preemption_cluster_utilization_threshold -%>
+  <property>
+    <name>yarn.scheduler.fair.preemption.cluster-utilization-threshold</name>
+    <value><%= @fair_preemption_cluster_utilization_threshold %></value>
+    <description>The utilization threshold after which preemption kicks in.</description>
+  </property>
+<% end # if @fair_preemption_cluster_utilization_threshold -%>
+<% if @fair_locality_threshold_node -%>
+  <property>
+    <name>yarn.scheduler.fair.locality.threshold.node</name>
+    <value><%= @fair_locality_threshold_node %></value>
+    <description>
+      For applications that request containers on particular nodes, the number of
+      scheduling opportunities since the last container assignment to wait before
+      accepting a placement on another node.
+    </description>
+  </property>
+<% end # if @fair_locality_threshold_node -%>
+<% end # if @fair_scheduler_enabled -%>
 
   <property>
     <name>yarn.nodemanager.localizer.address</name>

--- a/templates/hadoop/yarn-site.xml.erb
+++ b/templates/hadoop/yarn-site.xml.erb
@@ -58,6 +58,17 @@
     </description>
   </property>
 <% end # if @fair_locality_threshold_node -%>
+<% if @fair_locality_threshold_rack -%>
+  <property>
+    <name>yarn.scheduler.fair.locality.threshold.rack</name>
+    <value><%= @fair_locality_threshold_rack %></value>
+    <description>
+      For applications that request containers on particular racks, the number of
+      scheduling opportunities since the last container assignment to wait before
+      accepting a placement on another rack.
+    </description>
+  </property>
+<% end # if @fair_locality_threshold_rack -%>
 <% end # if @fair_scheduler_enabled -%>
 
   <property>


### PR DESCRIPTION
Preemption（中断）可以防止 app 因为集群资源不足而一直等待，默认设置为等待 30 秒（`$default_fair_share_preemption_timeout`）后如果还没有分配资源就强行中断其它 app 的 container，以达到释放资源的目的。

Locality 设置（`$fair_locality_threshold_node` 和 `$fair_locality_threshold_rack`）是为了在分配节点失败时多等待一段时间，尽量达到 locality 的原则。
